### PR TITLE
Update secret_keys dependency to release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 2.7.0
-before_install: gem install bundler -v 2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    secret_keys_rails (0.1.0)
+    secret_keys_rails (0.1.1)
       ice_nine
       rails (>= 4)
-      secret_keys (>= 1.0.0.pre)
+      secret_keys (~> 1.0)
       thor
 
 GEM
@@ -178,7 +178,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rake (12.3.3)
     ruby-progressbar (1.10.1)
-    secret_keys (1.0.0.pre)
+    secret_keys (1.0.1)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/secret_keys_rails.gemspec
+++ b/secret_keys_rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "secret_keys", ">= 1.0.0.pre"
+  spec.add_dependency "secret_keys", "~> 1.0"
   spec.add_dependency "rails", ">= 4"
   spec.add_dependency "ice_nine"
   spec.add_dependency "thor"


### PR DESCRIPTION
Released v1.0.1 of secret_keys, so change from using the prerelease version and apply a pessimistic versioning constraint.

Also removed `.travis.yml` since it was blowing up and looks like you've switched over to using Github Actions.